### PR TITLE
Add database_dialect as a supported database option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,7 @@ resource "google_spanner_database" "default" {
   for_each            = local.databases
   instance            = google_spanner_instance.default.name
   name                = each.value.name
+  database_dialect    = coalesce(each.value.database_dialect, "GOOGLE_STANDARD_SQL")
   deletion_protection = each.value.deletion_protection
 }
 

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "google_spanner_database" "default" {
   instance            = google_spanner_instance.default.name
   name                = each.value.name
   database_dialect    = coalesce(each.value.database_dialect, "GOOGLE_STANDARD_SQL")
-  deletion_protection = each.value.deletion_protection ? true : false
+  deletion_protection = coalesce(each.value.deletion_protection, true) ? true : false
 }
 
 # Instance IAM

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  experiments = [module_variable_optional_attrs]
+}
+
 locals {
   master_instance_name = var.random_instance_name ? "${var.name}-${random_id.suffix[0].hex}" : var.name
   instance_iam         = { for iam in var.instance_iam : iam.role => iam }

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "google_spanner_database" "default" {
 }
 
 # Instance IAM
-resource "google_spanner_instance_iam_binding" "instance" {
+resource "google_spanner_instance_iam_member" "instance" {
   for_each = local.instance_iam
   instance = google_spanner_instance.default.name
   role     = each.value.role

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   master_instance_name = var.random_instance_name ? "${var.name}-${random_id.suffix[0].hex}" : var.name
   instance_iam         = { for iam in var.instance_iam : iam.role => iam }
   databases            = { for db in var.databases : db.name => db }
-  database_ids         = [for item in var.databases : item.name]
+  database_ids = [ for item in var.databases: item.name ]
 }
 
 resource "random_id" "suffix" {
@@ -29,11 +29,11 @@ resource "google_spanner_database" "default" {
 }
 
 # Instance IAM
-resource "google_spanner_instance_iam_member" "instance" {
+resource "google_spanner_instance_iam_binding" "instance" {
   for_each = local.instance_iam
   instance = google_spanner_instance.default.name
   role     = each.value.role
-  member   = each.value.members
+  members  = each.value.members
 }
 
 # Database IAM
@@ -45,12 +45,12 @@ module "db-iam" {
 
 # Databases Backup
 module "automated-db-backup" {
-  count               = var.enable_automated_backup ? 1 : 0
-  source              = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=v0.1.2"
-  database_ids        = local.database_ids
+  count = var.enable_automated_backup ? 1 : 0
+  source  = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=v0.1.2"
+  database_ids = local.database_ids
   spanner_instance_id = google_spanner_instance.default.name
-  gcp_project_id      = var.gcp_project_id
-  location            = var.location
-  pubsub_topic        = var.pubsub_topic
-  region              = var.region
+  gcp_project_id = var.gcp_project_id
+  location = var.location
+  pubsub_topic = var.pubsub_topic
+  region = var.region
 }

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "google_spanner_database" "default" {
   instance            = google_spanner_instance.default.name
   name                = each.value.name
   database_dialect    = coalesce(each.value.database_dialect, "GOOGLE_STANDARD_SQL")
-  deletion_protection = each.value.deletion_protection
+  deletion_protection = each.value.deletion_protection ? true : false
 }
 
 # Instance IAM

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   master_instance_name = var.random_instance_name ? "${var.name}-${random_id.suffix[0].hex}" : var.name
   instance_iam         = { for iam in var.instance_iam : iam.role => iam }
   databases            = { for db in var.databases : db.name => db }
-  database_ids = [ for item in var.databases: item.name ]
+  database_ids         = [for item in var.databases : item.name]
 }
 
 resource "random_id" "suffix" {
@@ -33,7 +33,7 @@ resource "google_spanner_instance_iam_member" "instance" {
   for_each = local.instance_iam
   instance = google_spanner_instance.default.name
   role     = each.value.role
-  members  = each.value.members
+  member   = each.value.members
 }
 
 # Database IAM
@@ -45,12 +45,12 @@ module "db-iam" {
 
 # Databases Backup
 module "automated-db-backup" {
-  count = var.enable_automated_backup ? 1 : 0
-  source  = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=v0.1.2"
-  database_ids = local.database_ids
+  count               = var.enable_automated_backup ? 1 : 0
+  source              = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=v0.1.2"
+  database_ids        = local.database_ids
   spanner_instance_id = google_spanner_instance.default.name
-  gcp_project_id = var.gcp_project_id
-  location = var.location
-  pubsub_topic = var.pubsub_topic
-  region = var.region
+  gcp_project_id      = var.gcp_project_id
+  location            = var.location
+  pubsub_topic        = var.pubsub_topic
+  region              = var.region
 }

--- a/spanner-db-iam/main.tf
+++ b/spanner-db-iam/main.tf
@@ -1,7 +1,7 @@
-resource "google_spanner_database_iam_member" "default" {
+resource "google_spanner_database_iam_binding" "default" {
   for_each = var.iams
   database = each.value.database_name
   instance = var.instance
-  member  = each.value.members
+  members  = each.value.members
   role     = each.value.role
 }

--- a/spanner-db-iam/main.tf
+++ b/spanner-db-iam/main.tf
@@ -2,6 +2,6 @@ resource "google_spanner_database_iam_member" "default" {
   for_each = var.iams
   database = each.value.database_name
   instance = var.instance
-  members  = each.value.members
+  member  = each.value.members
   role     = each.value.role
 }

--- a/spanner-db-iam/main.tf
+++ b/spanner-db-iam/main.tf
@@ -1,4 +1,4 @@
-resource "google_spanner_database_iam_binding" "default" {
+resource "google_spanner_database_iam_member" "default" {
   for_each = var.iams
   database = each.value.database_name
   instance = var.instance

--- a/variables.tf
+++ b/variables.tf
@@ -21,12 +21,14 @@ variable "processing_units" {
   default     = 1000
 }
 
+# database_dialect values: GOOGLE_STANDARD_SQL, POSTGRESQL
 variable "databases" {
   description = "A list of databases to be created"
   type = list(object({
-    name      = string
-    charset   = string
-    collation = string
+    name                = string
+    charset             = string
+    collation           = string
+    database_dialect    = string # OPTIONAL, default GOOGLE_STANDARD_SQL
     deletion_protection = bool
   }))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,8 +28,8 @@ variable "databases" {
     name                = string
     charset             = string
     collation           = string
-    database_dialect    = string # OPTIONAL, default GOOGLE_STANDARD_SQL
-    deletion_protection = bool
+    database_dialect    = optional(string) # default GOOGLE_STANDARD_SQL
+    deletion_protection = optional(bool) # default false
   }))
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -41,42 +41,43 @@ variable "database_iam" {
   }))
 }
 
-variable config {
-  type = string
+variable "config" {
+  type        = string
   description = "The name of the instance's configuration (similar but not quite the same as a region)"
-  default = "regional-us-central1"
+  default     = "regional-us-central1"
 }
 
-variable deletion_protection {
-  type = bool
+variable "deletion_protection" {
+  type    = bool
   default = false
 }
 
 # Optional Database Backup
 variable "enable_automated_backup" {
-  type = bool
+  type        = bool
   description = "Enable Spanner Automated Databases Backup for the instance"
-  default = false
+  default     = false
 }
 
 variable "gcp_project_id" {
-  type = string
-  description = "GCP project in which the spanner instance exist"
+  type        = string
+  description = "GCP project in which the spanner backup exist"
+  default     = ""
 }
 
 variable "location" {
   type        = string
   description = "Location for App Engine"
-  default = "us-central"
+  default     = "us-central"
 }
 
 variable "pubsub_topic" {
-  type = string
+  type    = string
   default = "spanner-scheduled-backup-topic"
 }
 
 variable "region" {
-  type = string
+  type        = string
   description = "GCP Region"
-  default = "us-central1"
+  default     = "us-central1"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "databases" {
     charset             = string
     collation           = string
     database_dialect    = optional(string) # default GOOGLE_STANDARD_SQL
-    deletion_protection = optional(bool) # default false
+    deletion_protection = optional(bool)   # default false
   }))
 }
 


### PR DESCRIPTION
Adds the ability to specify `GOOGLE_STANDARD_SQL` or `POSTGRESQL` as a database dialect.  Defaults to `GOOGLE_STANDARD_SQL` if none is specified.