### PR TITLE
Update backup variable naming and other defaults

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ module "automated-db-backup" {
   database_ids        = local.database_ids
   spanner_instance_id = google_spanner_instance.default.name
   gcp_project_id      = data.google_client_config.this.project
-  location            = var.backup_location
+  location            = var.backup_app_engine_location
   pubsub_topic        = var.backup_pubsub_topic
   region              = var.backup_region
 }

--- a/main.tf
+++ b/main.tf
@@ -20,11 +20,6 @@ locals {
 
 data "google_client_config" "this" {}
 
-resource "random_id" "suffix" {
-  count       = var.random_instance_name ? 1 : 0
-  byte_length = 4
-}
-
 resource "google_spanner_instance" "default" {
   config           = var.config
   display_name     = var.display_name

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,6 @@ terraform {
 }
 
 locals {
-  master_instance_name = var.random_instance_name ? "${var.name}-${random_id.suffix[0].hex}" : var.name
   #  instance_iam         = { for iam in var.instance_iam : iam.role => iam }
   instance_role_member = flatten([
     for iamEntry in var.instance_iam :
@@ -28,8 +27,8 @@ resource "random_id" "suffix" {
 
 resource "google_spanner_instance" "default" {
   config           = var.config
-  display_name     = local.master_instance_name
-  name             = local.master_instance_name
+  display_name     = var.display_name
+  name             = var.name
   processing_units = var.processing_units
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,6 @@ variable "database_iam" {
 variable "config" {
   type        = string
   description = "The name of the instance's configuration (e.g. staging: us-west1, europe-west-1, asia-east2 | prod: nam10, eur5, asia1 | see https://cloud.google.com/spanner/docs/instance-configurations)"
-  default     = ""
 }
 
 variable "deletion_protection" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "random_instance_name" {
   description = "Sets random suffix at the end of the instance resource name"
   default     = false
 }
+
+variable "display_name" {
+  type        = string
+  description = "The display name of the instance"
+}
+
 variable "name" {
   type        = string
   description = "The name of the instance"

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,3 @@
-variable "random_instance_name" {
-  type        = bool
-  description = "Sets random suffix at the end of the instance resource name"
-  default     = false
-}
-
 variable "display_name" {
   type        = string
   description = "The display name of the instance"

--- a/variables.tf
+++ b/variables.tf
@@ -43,8 +43,8 @@ variable "database_iam" {
 
 variable "config" {
   type        = string
-  description = "The name of the instance's configuration (similar but not quite the same as a region)"
-  default     = "regional-us-central1"
+  description = "The name of the instance's configuration (e.g. staging: us-west1, europe-west-1, asia-east2 | prod: nam10, eur5, asia1 | see https://cloud.google.com/spanner/docs/instance-configurations)"
+  default     = ""
 }
 
 variable "deletion_protection" {
@@ -53,31 +53,25 @@ variable "deletion_protection" {
 }
 
 # Optional Database Backup
-variable "enable_automated_backup" {
+variable "backup_enabled" {
   type        = bool
   description = "Enable Spanner Automated Databases Backup for the instance"
   default     = false
 }
 
-variable "gcp_project_id" {
+variable "backup_app_engine_location" {
   type        = string
-  description = "GCP project in which the spanner backup exist"
+  description = "Location for App Engine"
   default     = ""
 }
 
-variable "location" {
-  type        = string
-  description = "Location for App Engine"
-  default     = "us-central"
-}
-
-variable "pubsub_topic" {
+variable "backup_pubsub_topic" {
   type    = string
   default = "spanner-scheduled-backup-topic"
 }
 
-variable "region" {
+variable "backup_region" {
   type        = string
-  description = "GCP Region"
-  default     = "us-central1"
+  description = "GCP Region to be used for GCS bucket and Cloud Scheduler job"
+  default     = ""
 }


### PR DESCRIPTION
The variable names for the backup weren't very explicit, and could be easily confused for Spanner instance configuration if someone isn't familiar with Spanner.  This updates the backup variables to be explicitly named, as well as clears setting a default config value, and clears the defaults for backup location and region so that the implementation gets what it expects.

Additionally updated to infer the project from the provider.