### PR TITLE
Allow backup configuration variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,10 +48,14 @@ module "db-iam" {
 
 # Databases Backup
 module "automated-db-backup" {
-  count              = (var.backup_enabled == true ? 1 : 0)
-  source             = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=v0.2.1"
-  database_names     = local.database_ids
-  instance_name      = google_spanner_instance.default.name
-  project_name       = data.google_client_config.this.project
-  backup_expire_time = var.backup_expire_time
+  count                  = (var.backup_enabled == true ? 1 : 0)
+  source                 = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=v0.2.1"
+  database_names         = local.database_ids
+  instance_name          = google_spanner_instance.default.name
+  project_name           = data.google_client_config.this.project
+  backup_deadline        = var.backup_deadline
+  backup_expire_time     = var.backup_expire_time
+  backup_schedule        = var.backup_schedule
+  backup_schedule_region = var.backup_schedule_region
+  backup_time_zone       = var.backup_time_zone
 }

--- a/main.tf
+++ b/main.tf
@@ -48,9 +48,10 @@ module "db-iam" {
 
 # Databases Backup
 module "automated-db-backup" {
-  count          = (var.backup_enabled == true ? 1 : 0)
-  source         = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=v0.2.1"
-  database_names = local.database_ids
-  instance_name  = google_spanner_instance.default.name
-  project_name   = data.google_client_config.this.project
+  count              = (var.backup_enabled == true ? 1 : 0)
+  source             = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=v0.2.1"
+  database_names     = local.database_ids
+  instance_name      = google_spanner_instance.default.name
+  project_name       = data.google_client_config.this.project
+  backup_expire_time = var.backup_expire_time
 }

--- a/variables.tf
+++ b/variables.tf
@@ -58,9 +58,32 @@ variable "backup_enabled" {
   description = "Enable Spanner Automated Databases Backup for the instance"
   default     = false
 }
+variable "backup_deadline" {
+  description = "The deadline for the backup schedule"
+  type        = string
+  default     = "320s"
+}
 
 variable "backup_expire_time" {
+  description = "Seconds until the backup expires"
   type        = number
-  description = "Backup exipiration time in seconds"
   default     = 86400
+}
+
+variable "backup_schedule" {
+  description = "The Backup Schedule in CRON format"
+  type        = string
+  default     = "0 0 * * *"
+}
+
+variable "backup_schedule_region" {
+  description = "The schedule to be enabled on scheduler to trigger spanner DB backup"
+  type        = string
+  default     = "us-west1"
+}
+
+variable "backup_time_zone" {
+  description = "The timezone to be used for the backup schedule"
+  type        = string
+  default     = "America/Vancouver"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "deletion_protection" {
 variable "backup_enabled" {
   type        = bool
   description = "Enable Spanner Automated Databases Backup for the instance"
-  default     = false
+  default     = true
 }
 variable "backup_deadline" {
   description = "The deadline for the backup schedule"

--- a/variables.tf
+++ b/variables.tf
@@ -58,3 +58,9 @@ variable "backup_enabled" {
   description = "Enable Spanner Automated Databases Backup for the instance"
   default     = false
 }
+
+variable "backup_expire_time" {
+  type        = number
+  description = "Backup exipiration time in seconds"
+  default     = 86400
+}


### PR DESCRIPTION
Expose variables from the backup module so implementations can decide for themselves.