### PR TITLE
More autoscaling refinements

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,8 +19,13 @@ resource "google_spanner_instance" "default" {
   config           = var.config
   display_name     = var.name
   name             = var.name
-  processing_units = var.autoscale_enabled == true ? var.autoscale_min_size : var.processing_units
   labels           = var.labels
+  dynamic {
+    for_each = var.autoscale_enabled == false ? [1] : []
+    content {
+  processing_units = var.processing_units
+    }
+  }
 }
 
 resource "google_spanner_database" "default" {

--- a/main.tf
+++ b/main.tf
@@ -19,12 +19,8 @@ resource "google_spanner_instance" "default" {
   config           = var.config
   display_name     = var.name
   name             = var.name
-  processing_units = var.processing_units
+  processing_units = var.autoscale_enabled == true ? var.autoscale_min_size : var.processing_units
   labels           = var.labels
-
-  lifecycle {
-    ignore_changes = var.autoscale_enabled == true ? [processing_units] : []
-  }
 }
 
 resource "google_spanner_database" "default" {

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,15 @@ resource "google_spanner_instance" "default" {
   name             = var.name
   processing_units = var.processing_units
   labels           = var.labels
+
+  dynamic "lifecycle" {
+    for_each = var.autoscale_enabled == true ? ["true"] : []
+    content {
+      lifecycle {
+        ignore_changes = [processing_units]
+      }
+    }
+  }
 }
 
 resource "google_spanner_database" "default" {

--- a/main.tf
+++ b/main.tf
@@ -22,13 +22,8 @@ resource "google_spanner_instance" "default" {
   processing_units = var.processing_units
   labels           = var.labels
 
-  dynamic "lifecycle" {
-    for_each = var.autoscale_enabled == true ? ["true"] : []
-    content {
-      lifecycle {
-        ignore_changes = [processing_units]
-      }
-    }
+  lifecycle {
+    ignore_changes = var.autoscale_enabled == true ? [processing_units] : []
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -19,13 +19,8 @@ resource "google_spanner_instance" "default" {
   config           = var.config
   display_name     = var.name
   name             = var.name
+  processing_units = var.autoscale_enabled == true ? var.autoscale_min_size : var.processing_units
   labels           = var.labels
-  dynamic {
-    for_each = var.autoscale_enabled == false ? [1] : []
-    content {
-  processing_units = var.processing_units
-    }
-  }
 }
 
 resource "google_spanner_database" "default" {


### PR DESCRIPTION
Final attempt to reduce toil for autoscaling processing units when applying more updates.  Sets the `processing_units` equal to the `autoscale_min_size` if autoscaling is enabled; otherwise sets to `processing_units`.