### PR TITLE
Autoscale long name override

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,17 +9,17 @@ locals {
       }
     ]
   ])
-  autoscale_bucket_gcf_name = var.autoscale_bucket_gcf_name != "" ? var.autoscale_bucket_gcf_name : "${var.name}-autoscaler-gcf-source"
-  autoscale_poller_job_name = var.autoscale_poller_job_name != "" ? var.autoscale_poller_job_name : "poll-${var.name}-spanner-metrics"
-  databases                 = { for db in var.databases : db.name => db }
-  database_ids              = [for item in var.databases : item.name]
+  alias_name   = var.aias_name != null ? var.aias_name : var.name
+  databases    = { for db in var.databases : db.name => db }
+  database_ids = [for item in var.databases : item.name]
+  display_name = var.display_name != null ? var.display_name : var.name
 }
 
 data "google_client_config" "this" {}
 
 resource "google_spanner_instance" "default" {
   config           = var.config
-  display_name     = var.name
+  display_name     = local.display_name
   name             = var.name
   processing_units = var.autoscale_enabled == true ? var.autoscale_min_size : var.processing_units
   labels           = var.labels
@@ -52,15 +52,14 @@ module "db-iam" {
 module "db-autoscaler" {
   count                          = (var.autoscale_enabled == true ? 1 : 0)
   source                         = "./spanner-autoscaler"
-  bucket_gcf_name                = local.autoscale_bucket_gcf_name
   max_size                       = var.autoscale_max_size
   min_size                       = var.autoscale_min_size
-  poller_job_name                = local.autoscale_poller_job_name
   project_id                     = data.google_client_config.this.project
   scale_in_cooling_minutes       = var.autoscale_in_cooling_minutes
   scale_out_cooling_minutes      = var.autoscale_out_cooling_minutes
   scaling_method                 = var.autoscale_method
   schedule                       = var.autoscale_schedule
+  spanner_alias_name             = google_spanner_instance.default.name
   spanner_name                   = google_spanner_instance.default.name
   spanner_state_name             = "${google_spanner_instance.default.name}-state"
   spanner_state_processing_units = 100
@@ -71,14 +70,14 @@ module "db-autoscaler" {
 # Databases Backup
 module "automated-db-backup" {
   count                  = (var.backup_enabled == true ? 1 : 0)
-  source                 = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=v0.2.2"
+  source                 = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=instance_alias"
   database_names         = local.database_ids
   instance_name          = google_spanner_instance.default.name
+  instance_alias_name    = var.backup_schedule_name
   project_name           = data.google_client_config.this.project
   backup_deadline        = var.backup_deadline
   backup_expire_time     = var.backup_expire_time
   backup_schedule        = var.backup_schedule
-  backup_schedule_name   = var.backup_schedule_name
   backup_schedule_region = var.backup_schedule_region
   backup_time_zone       = var.backup_time_zone
 }

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ module "db-autoscaler" {
 # Databases Backup
 module "automated-db-backup" {
   count                  = (var.backup_enabled == true ? 1 : 0)
-  source                 = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=instance_alias"
+  source                 = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=v0.2.3"
   database_names         = local.database_ids
   instance_name          = google_spanner_instance.default.name
   instance_alias_name    = local.alias_name

--- a/main.tf
+++ b/main.tf
@@ -80,5 +80,4 @@ module "automated-db-backup" {
   backup_schedule        = var.backup_schedule
   backup_schedule_region = var.backup_schedule_region
   backup_time_zone       = var.backup_time_zone
-  short_name             = local.short_name
 }

--- a/main.tf
+++ b/main.tf
@@ -9,10 +9,10 @@ locals {
       }
     ]
   ])
-  alias_name   = var.aias_name != null ? var.aias_name : var.name
+  alias_name   = var.alias_name != "" ? var.alias_name : var.name
   databases    = { for db in var.databases : db.name => db }
   database_ids = [for item in var.databases : item.name]
-  display_name = var.display_name != null ? var.display_name : var.name
+  display_name = var.display_name != "" ? var.display_name : var.name
 }
 
 data "google_client_config" "this" {}

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ module "db-autoscaler" {
   scale_out_cooling_minutes      = var.autoscale_out_cooling_minutes
   scaling_method                 = var.autoscale_method
   schedule                       = var.autoscale_schedule
-  spanner_alias_name             = google_spanner_instance.default.name
+  spanner_alias_name             = local.alias_name
   spanner_name                   = google_spanner_instance.default.name
   spanner_state_name             = "${google_spanner_instance.default.name}-state"
   spanner_state_processing_units = 100
@@ -73,7 +73,7 @@ module "automated-db-backup" {
   source                 = "github.com/dapperlabs-platform/terraform-gcp-spanner-backup?ref=instance_alias"
   database_names         = local.database_ids
   instance_name          = google_spanner_instance.default.name
-  instance_alias_name    = var.backup_schedule_name
+  instance_alias_name    = local.alias_name
   project_name           = data.google_client_config.this.project
   backup_deadline        = var.backup_deadline
   backup_expire_time     = var.backup_expire_time

--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,7 @@ module "automated-db-backup" {
   backup_deadline        = var.backup_deadline
   backup_expire_time     = var.backup_expire_time
   backup_schedule        = var.backup_schedule
+  backup_schedule_name   = var.backup_schedule_name
   backup_schedule_region = var.backup_schedule_region
   backup_time_zone       = var.backup_time_zone
 }

--- a/spanner-autoscaler/main.tf
+++ b/spanner-autoscaler/main.tf
@@ -33,13 +33,13 @@ module "scheduler" {
 
   max_size                  = var.max_size
   min_size                  = var.min_size
-  poller_job_name           = var.poller_job_name
   project_id                = var.project_id
   pubsub_topic              = module.autoscaler-functions.poller_topic
   scale_in_cooling_minutes  = var.scale_in_cooling_minutes
   scale_out_cooling_minutes = var.scale_out_cooling_minutes
   scaling_method            = var.scaling_method
   schedule                  = var.schedule
+  spanner_alias_name        = var.spanner_alias_name
   spanner_name              = var.spanner_name
   spanner_state_name        = var.spanner_state_name
   target_pubsub_topic       = module.autoscaler-functions.scaler_topic

--- a/spanner-autoscaler/main.tf
+++ b/spanner-autoscaler/main.tf
@@ -12,7 +12,7 @@ module "autoscaler-functions" {
   poller_sa_email = module.autoscaler-base.poller_sa_email
   region          = var.region
   scaler_sa_email = module.autoscaler-base.scaler_sa_email
-  spanner_name    = var.spanner_name
+  bucket_gcf_name = var.bucket_gcf_name
 }
 
 module "spanner" {
@@ -33,6 +33,7 @@ module "scheduler" {
 
   max_size                  = var.max_size
   min_size                  = var.min_size
+  poller_job_name           = var.poller_job_name
   project_id                = var.project_id
   pubsub_topic              = module.autoscaler-functions.poller_topic
   scale_in_cooling_minutes  = var.scale_in_cooling_minutes

--- a/spanner-autoscaler/main.tf
+++ b/spanner-autoscaler/main.tf
@@ -8,11 +8,11 @@ module "autoscaler-base" {
 module "autoscaler-functions" {
   source = "./modules/autoscaler-functions"
 
-  project_id      = var.project_id
-  poller_sa_email = module.autoscaler-base.poller_sa_email
-  region          = var.region
-  scaler_sa_email = module.autoscaler-base.scaler_sa_email
-  bucket_gcf_name = var.bucket_gcf_name
+  project_id         = var.project_id
+  poller_sa_email    = module.autoscaler-base.poller_sa_email
+  region             = var.region
+  scaler_sa_email    = module.autoscaler-base.scaler_sa_email
+  spanner_alias_name = var.spanner_alias_name
 }
 
 module "spanner" {

--- a/spanner-autoscaler/modules/autoscaler-functions/main.tf
+++ b/spanner-autoscaler/modules/autoscaler-functions/main.tf
@@ -65,7 +65,7 @@ resource "google_pubsub_topic_iam_member" "scaler_pubsub_sub_iam" {
 
 // Cloud Functions
 resource "google_storage_bucket" "bucket_gcf_source" {
-  name                        = var.bucket_gcf_name
+  name                        = "${var.spanner_alias_name}-gcf-source-${random_id.suffix.hex}"
   storage_class               = "REGIONAL"
   location                    = var.region
   force_destroy               = "true"

--- a/spanner-autoscaler/modules/autoscaler-functions/main.tf
+++ b/spanner-autoscaler/modules/autoscaler-functions/main.tf
@@ -65,7 +65,7 @@ resource "google_pubsub_topic_iam_member" "scaler_pubsub_sub_iam" {
 
 // Cloud Functions
 resource "google_storage_bucket" "bucket_gcf_source" {
-  name                        = "${var.spanner_name}-autoscaler-gcf-source"
+  name                        = var.bucket_gcf_name
   storage_class               = "REGIONAL"
   location                    = var.region
   force_destroy               = "true"

--- a/spanner-autoscaler/modules/autoscaler-functions/variables.tf
+++ b/spanner-autoscaler/modules/autoscaler-functions/variables.tf
@@ -47,7 +47,7 @@ variable "forwarder_sa_emails" {
   default = []
 }
 
-variable "spanner_name" {
-  description = "Name of the Spanner instance to be autoscaled."
+variable "bucket_gcf_name" {
   type        = string
+  description = "Name of the GCF bucket that will be created to hold the source files for the poller and scaler functions.  Useful for name or name length conflicts."
 }

--- a/spanner-autoscaler/modules/autoscaler-functions/variables.tf
+++ b/spanner-autoscaler/modules/autoscaler-functions/variables.tf
@@ -47,7 +47,7 @@ variable "forwarder_sa_emails" {
   default = []
 }
 
-variable "bucket_gcf_name" {
+variable "spanner_alias_name" {
   type        = string
-  description = "Name of the GCF bucket that will be created to hold the source files for the poller and scaler functions.  Useful for name or name length conflicts."
+  description = "Alias for the spanner instance.  Useful for name length conflicts."
 }

--- a/spanner-autoscaler/modules/scheduler/main.tf
+++ b/spanner-autoscaler/modules/scheduler/main.tf
@@ -46,7 +46,7 @@ locals {
 # }
 
 resource "google_cloud_scheduler_job" "poller_job" {
-  name        = "poll-${var.spanner_name}-spanner-metrics"
+  name        = var.poller_job_name
   description = "Poll metrics for ${var.spanner_name}"
   schedule    = var.schedule
   time_zone   = var.time_zone

--- a/spanner-autoscaler/modules/scheduler/main.tf
+++ b/spanner-autoscaler/modules/scheduler/main.tf
@@ -46,7 +46,7 @@ locals {
 # }
 
 resource "google_cloud_scheduler_job" "poller_job" {
-  name        = var.poller_job_name
+  name        = "poll-${var.spanner_alias_name}-spanner-metrics"
   description = "Poll metrics for ${var.spanner_name}"
   schedule    = var.schedule
   time_zone   = var.time_zone

--- a/spanner-autoscaler/modules/scheduler/variables.tf
+++ b/spanner-autoscaler/modules/scheduler/variables.tf
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+ 
 variable "project_id" {
   type = string
 }
@@ -103,4 +103,9 @@ variable "json_config" {
   type        = string
   default     = ""
   description = "Base 64 encoded json that is the autoscaler configuration for the Cloud Scheduler payload. Using this allows for setting autoscaler configuration for multiple spanners and parameters that are not directly exposed through variables."
+}
+
+variable "poller_job_name" {
+  type        = string
+  description = "Override the name used for the poller job.  Useful if the generated name is too long or has a conflict."
 }

--- a/spanner-autoscaler/modules/scheduler/variables.tf
+++ b/spanner-autoscaler/modules/scheduler/variables.tf
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 variable "project_id" {
   type = string
 }
@@ -105,7 +105,7 @@ variable "json_config" {
   description = "Base 64 encoded json that is the autoscaler configuration for the Cloud Scheduler payload. Using this allows for setting autoscaler configuration for multiple spanners and parameters that are not directly exposed through variables."
 }
 
-variable "poller_job_name" {
+variable "spanner_alias_name" {
   type        = string
-  description = "Override the name used for the poller job.  Useful if the generated name is too long or has a conflict."
+  description = "Alias for the spanner instance.  Useful for name length conflicts."
 }

--- a/spanner-autoscaler/variables.tf
+++ b/spanner-autoscaler/variables.tf
@@ -42,6 +42,11 @@ variable "schedule" {
   default = "*/2 * * * *"
 }
 
+variable "spanner_alias_name" {
+  type        = string
+  description = "Alias for the spanner instance.  Useful for name length conflicts."
+}
+
 variable "spanner_name" {
   type    = string
   default = "autoscale-test"
@@ -61,14 +66,4 @@ variable "terraform_spanner_state" {
   description = "If set to true, Terraform will create a Cloud Spanner instance and DB to hold the Autoscaler state."
   type        = bool
   default     = false
-}
-
-variable "bucket_gcf_name" {
-  type        = string
-  description = "Name of the GCF bucket that will be created to hold the source files for the poller and scaler functions.  Useful for name or name length conflicts."
-}
-
-variable "poller_job_name" {
-  type        = string
-  description = "Override the name used for the poller job.  Useful if the generated name is too long or has a conflict."
 }

--- a/spanner-autoscaler/variables.tf
+++ b/spanner-autoscaler/variables.tf
@@ -62,3 +62,13 @@ variable "terraform_spanner_state" {
   type        = bool
   default     = false
 }
+
+variable "bucket_gcf_name" {
+  type        = string
+  description = "Name of the GCF bucket that will be created to hold the source files for the poller and scaler functions.  Useful for name or name length conflicts."
+}
+
+variable "poller_job_name" {
+  type        = string
+  description = "Override the name used for the poller job.  Useful if the generated name is too long or has a conflict."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -130,6 +130,12 @@ variable "backup_schedule" {
   default     = "0 0 * * *"
 }
 
+variable "backup_schedule_name" {
+  type        = string
+  default     = ""
+  description = "Override the name used for the schedule.  Useful if the generated name is too long or has a conflict."
+}
+
 variable "backup_schedule_region" {
   description = "The schedule to be enabled on scheduler to trigger spanner DB backup"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "deletion_protection" {
 }
 
 # Optional Autoscaling
+variable "autoscale_bucket_gcf_name" {
+  type        = string
+  default     = ""
+  description = "Name of the GCF bucket that will be created to hold the source files for the poller and scaler functions.  Useful for name or name length conflicts."
+}
+
 variable "autoscale_enabled" {
   type        = bool
   description = "Enable autoscaling for the spanner instance"
@@ -87,6 +93,12 @@ variable "autoscale_min_size" {
   type        = number
   default     = 100
   description = "Minimum size that the spanner instance can be scaled in to."
+}
+
+variable "autoscale_poller_job_name" {
+  type        = string
+  default     = ""
+  description = "Override the name used for the poller job.  Useful if the generated name is too long or has a conflict."
 }
 
 variable "autoscale_schedule" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,15 @@
+variable "alias_name" {
+  type        = string
+  description = "The alias to use for naming dependent objects, such as service accounts, for the instance to avoid name/length conflicts"
+  default     = ""
+}
+
+variable "display_name" {
+  type        = string
+  description = "The display name of the instance"
+  default     = ""
+}
+
 variable "name" {
   type        = string
   description = "The name of the instance"


### PR DESCRIPTION
Adds an alias name variable to override name for computed resource names; adds back in `display_name` so we can add a friendly name where appropriate.