### PR TITLE
Apply alias to spanner state name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ module "db-autoscaler" {
   schedule                       = var.autoscale_schedule
   spanner_alias_name             = local.alias_name
   spanner_name                   = google_spanner_instance.default.name
-  spanner_state_name             = "${google_spanner_instance.default.name}-state"
+  spanner_state_name             = "${local.alias_name}-state"
   spanner_state_processing_units = 100
   terraform_spanner_state        = true
   depends_on                     = [google_spanner_database.default]

--- a/variables.tf
+++ b/variables.tf
@@ -65,12 +65,6 @@ variable "deletion_protection" {
 }
 
 # Optional Autoscaling
-variable "autoscale_bucket_gcf_name" {
-  type        = string
-  default     = ""
-  description = "Name of the GCF bucket that will be created to hold the source files for the poller and scaler functions.  Useful for name or name length conflicts."
-}
-
 variable "autoscale_enabled" {
   type        = bool
   description = "Enable autoscaling for the spanner instance"
@@ -105,12 +99,6 @@ variable "autoscale_min_size" {
   type        = number
   default     = 100
   description = "Minimum size that the spanner instance can be scaled in to."
-}
-
-variable "autoscale_poller_job_name" {
-  type        = string
-  default     = ""
-  description = "Override the name used for the poller job.  Useful if the generated name is too long or has a conflict."
 }
 
 variable "autoscale_schedule" {


### PR DESCRIPTION
Leverage the alias for state spanner naming; remove some unnecessary variables