### PR TITLE
Hardcode project name to prevent thrashing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,6 @@ locals {
   display_name = var.display_name != "" ? var.display_name : var.name
 }
 
-data "google_client_config" "this" {}
-
 resource "google_spanner_instance" "default" {
   config           = var.config
   display_name     = local.display_name
@@ -54,7 +52,7 @@ module "db-autoscaler" {
   source                         = "./spanner-autoscaler"
   max_size                       = var.autoscale_max_size
   min_size                       = var.autoscale_min_size
-  project_id                     = data.google_client_config.this.project
+  project_id                     = var.project_id
   scale_in_cooling_minutes       = var.autoscale_in_cooling_minutes
   scale_out_cooling_minutes      = var.autoscale_out_cooling_minutes
   scaling_method                 = var.autoscale_method
@@ -74,7 +72,7 @@ module "automated-db-backup" {
   database_names         = local.database_ids
   instance_name          = google_spanner_instance.default.name
   instance_alias_name    = local.alias_name
-  project_name           = data.google_client_config.this.project
+  project_name           = var.project_id
   backup_deadline        = var.backup_deadline
   backup_expire_time     = var.backup_expire_time
   backup_schedule        = var.backup_schedule

--- a/spanner-autoscaler/modules/autoscaler-functions/main.tf
+++ b/spanner-autoscaler/modules/autoscaler-functions/main.tf
@@ -82,6 +82,10 @@ resource "google_storage_bucket_object" "gcs_functions_poller_source" {
   name   = "poller.${random_id.suffix.hex}.zip"
   bucket = google_storage_bucket.bucket_gcf_source.name
   source = data.archive_file.local_poller_source.output_path
+
+  lifecycle {
+    ignore_changes = [detect_md5hash]
+  }
 }
 
 data "archive_file" "local_scaler_source" {
@@ -94,6 +98,10 @@ resource "google_storage_bucket_object" "gcs_functions_scaler_source" {
   name   = "scaler.${random_id.suffix.hex}.zip"
   bucket = google_storage_bucket.bucket_gcf_source.name
   source = data.archive_file.local_scaler_source.output_path
+
+  lifecycle {
+    ignore_changes = [detect_md5hash]
+  }
 }
 
 resource "google_cloudfunctions_function" "poller_function" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "project_id" {
+  type        = string
+  description = "The name of the GCP project"
+}
+
 variable "alias_name" {
   type        = string
   description = "The alias to use for naming dependent objects, such as service accounts, for the instance to avoid name/length conflicts"


### PR DESCRIPTION
- Passing in `project` as a variable to prevent "thrashing" in Terraform plans/applies. 
- Ignores `detect_md5hash` changes in `google_storage_bucket_object` as we expect these files to change and don't want to force a recreation each time Terraform detects a difference in the objects. This will also prevent thrashing