### PR TITLE
ignore scaling changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,10 @@ resource "google_spanner_instance" "default" {
   name             = var.name
   processing_units = var.autoscale_enabled == true ? var.autoscale_min_size : var.processing_units
   labels           = var.labels
+
+  lifecycle {
+    ignore_changes = [processing_units]
+  }
 }
 
 resource "google_spanner_database" "default" {


### PR DESCRIPTION
When Spanner is scaled ignore changes to processing unit so it doesn't scale down